### PR TITLE
Add ability to POST and also send data on GET and POST requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+- Added: `payload` and `method` arguments.
+
 ## 0.1.0
 
 - Added: `use-api` hook.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 ## Unreleased
 
 - Added: `payload` and `method` arguments.
+- Change: LICENSE copyright.
 
 ## 0.1.1
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ const PeopleList = () = {
 }
 ```
 
-You can optionally pass in data as the final argument to turn the request into a `POST` request. Below is a minimal example of a user search UI. (You may wish to debounce the user input 🤷‍)
+You can optionally pass in data and specify the request type. Below is a minimal example of a user search UI. (You may wish to debounce the user input 🤷‍)
 
 ```JSX
 import React, { useState } from 'react';
@@ -57,9 +57,9 @@ import useApi from '@signal-noise/use-api';
 import PeopleList from './PeopleList';
 
 const PeopleSearch = () = {
-  const [keywords, setKeywords] = useState("marcel");
+  const [keywords, setKeywords] = useState("kazumi");
 
-  const { data } = useApi("https://some-api.com", 0, { keywords });
+  const { data } = useApi("https://some-api.com", 0, { keywords }, "post");
 
   const people = data.people || [];
 
@@ -77,8 +77,9 @@ const PeopleSearch = () = {
 ### Input
 
 - `apiEndpoint` - A URL to request data from.
-- `pollInterval` - How often to re-request updated data. Pass 0 to disable polling (its default behaviour).
-- `postData` - Pass an object to change the request to a POST and pass along the data.
+- `pollInterval` - How often to re-request updated data. Pass 0 to disable polling (the default behaviour).
+- `payload` - A data object to send in the request. If we are performing a GET request, it is appended into the querystring (e.g. `?keywords=hello`). If it is a POST request it is sent in the request body as JSON.
+- `method` - Set the request type, either `get` or `post`. (defaults to `get`)
 
 ### Output
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ const PeopleList = () = {
 }
 ```
 
-You can optionally pass in data as the final argument to turn the request into a `POST` request. Below is an example of a simple user search. (You may wish to debounce the user input 🤷‍)
+You can optionally pass in data as the final argument to turn the request into a `POST` request. Below is a minimal example of a user search UI. (You may wish to debounce the user input 🤷‍)
 
 ```JSX
 import React, { useState } from 'react';
@@ -59,14 +59,12 @@ import PeopleList from './PeopleList';
 const PeopleSearch = () = {
   const [keywords, setKeywords] = useState("marcel");
 
-  const { data, loading, error, refresh } = useApi("https://some-api.com", 0, { keywords });
+  const { data } = useApi("https://some-api.com", 0, { keywords });
 
   const people = data.people || [];
 
   return (
     <>
-      {loading && <p>Loading...</p>}
-      {error && <p>{error}</p>}
       <input value={keywords} onChange={e=>setKeywords(e.target.value)} />
       <PeopleList people={data.people} />
     </>

--- a/README.md
+++ b/README.md
@@ -26,21 +26,50 @@ npm i @signal-noise/use-api
 
 ## Usage
 
-Here is an example of an api call to retrieve a list of people which polls every 10 seconds, with a manual refresh button.
+Here is an example of a `GET` api call to retrieve a list of people which polls every 10 seconds, with a manual refresh button.
 
 ```JSX
 import React from 'react';
 import useApi from '@signal-noise/use-api';
 import PeopleList from './PeopleList';
 
-const App = () = {
+const PeopleList = () = {
   const { data, loading, error, refresh } = useApi("https://some-api.com", 10000);
 
+  const people = data.people || [];
+
   return (
-    {loading && <p>Loading...</p>}
-    {error && <p>{error}</p>}
-    <button onClick={refresh} disabled={loading}>Refresh</button>
-    {!loading && <PeopleList people={data.people}>}
+    <>
+      {loading && <p>Loading...</p>}
+      {error && <p>{error}</p>}
+      <button onClick={refresh} disabled={loading}>Refresh</button>
+      <PeopleList people={people} />
+    </>
+  );
+}
+```
+
+You can optionally pass in data as the final argument to turn the request into a `POST` request. Below is an example of a simple user search. (You may wish to debounce the user input 🤷‍)
+
+```JSX
+import React, { useState } from 'react';
+import useApi from '@signal-noise/use-api';
+import PeopleList from './PeopleList';
+
+const PeopleSearch = () = {
+  const [keywords, setKeywords] = useState("marcel");
+
+  const { data, loading, error, refresh } = useApi("https://some-api.com", 0, { keywords });
+
+  const people = data.people || [];
+
+  return (
+    <>
+      {loading && <p>Loading...</p>}
+      {error && <p>{error}</p>}
+      <input value={keywords} onChange={e=>setKeywords(e.target.value)} />
+      <PeopleList people={data.people} />
+    </>
   );
 }
 ```
@@ -50,7 +79,8 @@ const App = () = {
 ### Input
 
 - `apiEndpoint` - A URL to request data from.
-- `pollInterval` - How often to re-request updated data.
+- `pollInterval` - How often to re-request updated data. Pass 0 to disable polling (its default behaviour).
+- `postData` - Pass an object to change the request to a POST and pass along the data.
 
 ### Output
 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ const useApi = (apiEndpoint, pollInterval, payload, method = "get") => {
   const [loading, setLoading] = useState(true);
   const [poll, setPoll] = useState(0);
 
+  method = method.toLowerCase();
+
   // Function to force a refresh
   const refresh = () => setPoll(poll + 1);
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const axios = require("axios");
 
 const { CancelToken } = axios;
 
-const useApi = (apiEndpoint, pollInterval) => {
+const useApi = (apiEndpoint, pollInterval, postData) => {
   const [data, setData] = useState({});
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -19,7 +19,8 @@ const useApi = (apiEndpoint, pollInterval) => {
 
     // Make call to the API
     axios(apiEndpoint, {
-      cancelToken: source.token
+      cancelToken: source.token,
+      ...(postData && { data: postData, method: "post" })
     })
       .then(response => {
         setError(null);

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const axios = require("axios");
 
 const { CancelToken } = axios;
 
-const useApi = (apiEndpoint, pollInterval, postData) => {
+const useApi = (apiEndpoint, pollInterval, payload, method = "get") => {
   const [data, setData] = useState({});
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -15,17 +15,21 @@ const useApi = (apiEndpoint, pollInterval, postData) => {
     // Create a token that we sign the request with so it can be cancelled if need be
     const source = CancelToken.source();
 
+    // Set loading to be true
     setLoading(true);
 
     // Make call to the API
     axios(apiEndpoint, {
+      method,
       cancelToken: source.token,
-      ...(postData && { data: postData, method: "post" })
+      ...(payload &&
+        (method === "get" ? { params: payload } : { data: payload }))
     })
       .then(response => {
         setError(null);
+        // Set the recieved data
         setData(response.data);
-      }) // Set the recieved data
+      })
       .catch(thrown => {
         // Only error on genuine errors, not cancellations
         if (!axios.isCancel(thrown)) setError(thrown.message);

--- a/index.js
+++ b/index.js
@@ -9,6 +9,9 @@ const useApi = (apiEndpoint, pollInterval, payload, method = "get") => {
   const [loading, setLoading] = useState(true);
   const [poll, setPoll] = useState(0);
 
+  // Function to force a refresh
+  const refresh = () => setPoll(poll + 1);
+
   useEffect(() => {
     let timeout;
 
@@ -26,6 +29,7 @@ const useApi = (apiEndpoint, pollInterval, payload, method = "get") => {
         (method === "get" ? { params: payload } : { data: payload }))
     })
       .then(response => {
+        // Make sure there are no errors reported
         setError(null);
         // Set the recieved data
         setData(response.data);
@@ -35,12 +39,11 @@ const useApi = (apiEndpoint, pollInterval, payload, method = "get") => {
         if (!axios.isCancel(thrown)) setError(thrown.message);
       })
       .finally(() => {
-        // Clear the loading and refreshing flags
+        // Clear the loading flag
         setLoading(false);
 
         // Poll if specified to do so
-        if (pollInterval)
-          timeout = setTimeout(() => setPoll(poll + 1), pollInterval);
+        if (pollInterval) timeout = setTimeout(refresh, pollInterval);
       });
 
     // Cleanup, clear a timeout and cancel the request.
@@ -49,9 +52,6 @@ const useApi = (apiEndpoint, pollInterval, payload, method = "get") => {
       source.cancel();
     };
   }, [poll, apiEndpoint, pollInterval]);
-
-  // Function to force a refresh
-  const refresh = () => setPoll(poll + 1);
 
   return { data, loading, error, refresh };
 };

--- a/index.js
+++ b/index.js
@@ -9,13 +9,19 @@ const useApi = (apiEndpoint, pollInterval, payload, method = "get") => {
   const [loading, setLoading] = useState(true);
   const [poll, setPoll] = useState(0);
 
-  method = method.toLowerCase();
-
   // Function to force a refresh
   const refresh = () => setPoll(poll + 1);
 
   useEffect(() => {
     let timeout;
+
+    if (method.toLowerCase) method = method.toLowerCase();
+
+    if (!["get", "post"].includes(method)) {
+      setLoading(false);
+      setError("Invalid request method type, must be either post or get.");
+      return;
+    }
 
     // Create a token that we sign the request with so it can be cancelled if need be
     const source = CancelToken.source();

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   ],
   "scripts": {
     "test": "jest",
-    "coverage": "jest --coverage"
+    "coverage": "jest --coverage",
+    "release": "np"
   },
   "author": "John Chipps-Harding (john@signal-noise.com)",
   "license": "MIT",

--- a/test.js
+++ b/test.js
@@ -3,25 +3,42 @@ const axios = require("axios");
 const useApi = require("./index");
 const { renderHook, act } = require("@testing-library/react-hooks");
 
-describe("performs GET requests", () => {
+describe("performs requests", () => {
   let mock;
   const url = "http://mock";
 
-  beforeAll(() => {
+  beforeEach(() => {
     mock = new MockAdapter(axios);
     jest.clearAllMocks();
     jest.useFakeTimers();
   });
 
-  afterAll(() => {
+  afterEach(() => {
     jest.useRealTimers();
     mock.restore();
   });
 
-  it("loads data from a url", async () => {
+  it("loads data from a url using GET", async () => {
     mock.onGet(url).reply(200, "response");
 
     const { result, waitForNextUpdate } = renderHook(() => useApi(url));
+
+    expect(result.current.data).toEqual({});
+    expect(result.current.loading).toBeTruthy();
+
+    await waitForNextUpdate();
+
+    expect(result.current.data).toEqual("response");
+    expect(result.current.loading).toBeFalsy();
+  });
+
+  it("loads data from a url using POST", async () => {
+    const postData = { query: "hello" };
+    mock.onPost(url, postData).reply(200, "response");
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useApi(url, 0, postData)
+    );
 
     expect(result.current.data).toEqual({});
     expect(result.current.loading).toBeTruthy();

--- a/test.js
+++ b/test.js
@@ -53,6 +53,45 @@ describe("performs requests", () => {
     expect(result.current.loading).toBeFalsy();
   });
 
+  it("allows different formats of GET method param (GET)", async () => {
+    mock.onGet(url).reply(200, "response");
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useApi(url, 0, { query: "hello" }, "GET")
+    );
+
+    await waitForNextUpdate();
+
+    expect(result.current.data).toEqual("response");
+    expect(result.current.loading).toBeFalsy();
+  });
+
+  it("allows different formats of GET method param (Get)", async () => {
+    mock.onGet(url).reply(200, "response");
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useApi(url, 0, { query: "hello" }, "Get")
+    );
+
+    await waitForNextUpdate();
+
+    expect(result.current.data).toEqual("response");
+    expect(result.current.loading).toBeFalsy();
+  });
+
+  it("allows different formats of GET method param (gEt)", async () => {
+    mock.onGet(url).reply(200, "response");
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useApi(url, 0, { query: "hello" }, "gEt")
+    );
+
+    await waitForNextUpdate();
+
+    expect(result.current.data).toEqual("response");
+    expect(result.current.loading).toBeFalsy();
+  });
+
   it("loads data from a url using POST", async () => {
     const postData = { query: "hello" };
     mock.onPost(url, postData).reply(200, "response");
@@ -67,6 +106,70 @@ describe("performs requests", () => {
     await waitForNextUpdate();
 
     expect(result.current.data).toEqual("response");
+    expect(result.current.loading).toBeFalsy();
+  });
+
+  it("allows different formats of POST method param (Post)", async () => {
+    const postData = { query: "hello" };
+    mock.onPost(url, postData).reply(200, "response");
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useApi(url, 0, postData, "Post")
+    );
+
+    await waitForNextUpdate();
+
+    expect(result.current.data).toEqual("response");
+    expect(result.current.loading).toBeFalsy();
+  });
+
+  it("allows different formats of POST method param (POST)", async () => {
+    const postData = { query: "hello" };
+    mock.onPost(url, postData).reply(200, "response");
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useApi(url, 0, postData, "POST")
+    );
+
+    await waitForNextUpdate();
+
+    expect(result.current.data).toEqual("response");
+    expect(result.current.loading).toBeFalsy();
+  });
+
+  it("allows different formats of POST method param (pOst)", async () => {
+    const postData = { query: "hello" };
+    mock.onPost(url, postData).reply(200, "response");
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useApi(url, 0, postData, "pOst")
+    );
+
+    await waitForNextUpdate();
+
+    expect(result.current.data).toEqual("response");
+    expect(result.current.loading).toBeFalsy();
+  });
+
+  it("warns about bad finding a bad string in method type", async () => {
+    mock.onGet(url).reply(200, "response");
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useApi(url, 0, { query: "hello" }, "POSTITNOIE")
+    );
+
+    expect(result.current.error).toBeTruthy();
+    expect(result.current.loading).toBeFalsy();
+  });
+
+  it("warns about garbage in method type", async () => {
+    mock.onGet(url).reply(200, "response");
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useApi(url, 0, { query: "hello" }, { something: "wrong" })
+    );
+
+    expect(result.current.error).toBeTruthy();
     expect(result.current.loading).toBeFalsy();
   });
 

--- a/test.js
+++ b/test.js
@@ -32,12 +32,33 @@ describe("performs requests", () => {
     expect(result.current.loading).toBeFalsy();
   });
 
+  it("sends querystring data and loads data from a url using GET", async () => {
+    const params = { query: "hello" };
+    mock
+      .onGet(url)
+      .reply(config =>
+        config.params.query === "hello" ? [200, "response"] : [400, "error"]
+      );
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useApi(url, 0, params)
+    );
+
+    expect(result.current.data).toEqual({});
+    expect(result.current.loading).toBeTruthy();
+
+    await waitForNextUpdate();
+
+    expect(result.current.data).toEqual("response");
+    expect(result.current.loading).toBeFalsy();
+  });
+
   it("loads data from a url using POST", async () => {
     const postData = { query: "hello" };
     mock.onPost(url, postData).reply(200, "response");
 
     const { result, waitForNextUpdate } = renderHook(() =>
-      useApi(url, 0, postData)
+      useApi(url, 0, postData, "post")
     );
 
     expect(result.current.data).toEqual({});


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #10 

> Is there anything in the PR that needs further explanation?

Added a third input argument (`postData`) for switching to a POST request and sending the data.
