### PR TITLE
EIUNAB-3645/Impact : Work with Teams to get the YAML into Backstage.io for all projects

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,7 @@
+- apiVersion: backstage.io/v1beta1
+  kind: System
+  metadata:
+    name: use-api
+    title: use-api
+    namespace: economist-impact
+    description: use-api for SignalNoise Economist Impact Project

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,4 +4,14 @@
     name: use-api
     title: use-api
     namespace: economist-impact
+    annotations: 
+      github.com/project-slug: signal-noise/use-api
+      # the circleCI project, mirrors github repo in this case: 
+    circleci.com/project-slug: github/signal-noise/use-api
+      # GUID - see https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard/
+    newrelic.com/dashboard-guid: MzY1MjgxOXxWSVp8REFTSEJPQVJEfGRhOjE3MDkwOA
+    newrelic.com/dashboard-guid: MzY1MjgxOXxWSVp8REFTSEJPQVJEfGRhOjE5NTIyNw
+    description: covid-relative-risk for SignalNoise Economist Impact Project
+    opsgenie:
+      domain: https://economist.app.opsgenie.com/teams/dashboard/49177ca8-5e59-4364-af23-c22cc60c026f/main
     description: use-api for SignalNoise Economist Impact Project


### PR DESCRIPTION
Description
Add to Backstage - Economist Impact Signal Noise Team

Reason for change
Backstage.io rollout across the Economist Group via platform.economist.com

Breaking changes
None

Remarks
Github added, CircleCI Added (where CICD applicable), New Relic added, Opsgenie added (where applicable), docs file added to be updated in depth by the team upon review.

Testing
Once merged the Enablement team will test integration into backstage. The yaml files are pulled via polling on the main branch for automated incorporation.

Checklist
My commits, pull request name follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
style
I have made corresponding changes to the documentation
I have updated unit tests, integration tests
I have tested in dev environment
I have update swagger, where applicable
I have provided cdk diff result for infrastructure changes, where applicable
